### PR TITLE
Written out Usage instructions, added comments for domain examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,31 @@ This is a bare-bones example to serve a single server (and multiple rooms) insta
 
 Usage
 ======
-TODO!
+Running a FroJS server instance based on this repository requires [NodeJS and npm](https://nodejs.org/download/). First, edit `src/config.js` to your liking (e.g. domains, port number, flood protection). Then, locally install required dependencies using `npm install`.
+
+Finally, run the instance in NodeJS using `node src/app.js`. You can optionally use [screen](http://www.gnu.org/software/screen/) or [tmux](https://tmux.github.io/) to run the server in a detachable terminal.
+
+## Domains
+Each entry under `config.domains` specifies an endpoint for FroJS-compliant clients to connect to, using a `ns` (or, the [socket.io namespace](http://socket.io/docs/rooms-and-namespaces/)) and `domain` value.
+
+For example, to allow FroJS clients to connect to the server using `http://localhost:3000/debug` or `http://universe.example.com:3000/`:
+```js
+config.domains = [
+    {
+        ns: 'debug',
+        domain: 'localhost'
+    },
+    {
+        ns: '',
+        domain: 'universe.example.com'
+    }
+];
+```
+
+Note that all connected clients can see each other regardless of what endpoint or namespace they use, provided they are in the same *room* (as dictated by the world's [`network` configuration](http://mcmanning.github.io/frojs/developers.html#configuration-network)).
+
+## Logging
+By default, this example logs to the console and `debug.log` in the current working directory. This can be changed in `src/logging.js` using [Winston configuration](https://github.com/winstonjs/winston#usage). Whilst FroJS is in early development or if testing, it is a good idea to keep logging levels to `debug`.
 
 Contributing
 ======

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Running a FroJS server instance based on this repository requires [NodeJS and np
 
 Finally, run the instance in NodeJS using `node src/app.js`. You can optionally use [screen](http://www.gnu.org/software/screen/) or [tmux](https://tmux.github.io/) to run the server in a detachable terminal.
 
+When configuring a FroJS client to connect to this example, the token should be set to the default `hi`.
+
 ## Domains
 Each entry under `config.domains` specifies an endpoint for FroJS-compliant clients to connect to, using a `ns` (or, the [socket.io namespace](http://socket.io/docs/rooms-and-namespaces/)) and `domain` value.
 

--- a/src/config.js
+++ b/src/config.js
@@ -12,11 +12,11 @@ config.port = process.env.PORT || 3000;
 // Domains registered to the server.
 // TODO: Come up with a better pattern of how domain mapping works.
 config.domains = [
-    {
+    { // Accept connections from http://sybolt.com:3000/sybolt
         ns: 'sybolt',
         domain: 'sybolt.com'
     },
-    {
+    { // Accept connections from http://universe.frojs.com:3000/test
         ns: 'test',
         domain: 'universe.frojs.com'
     }


### PR DESCRIPTION
Written from my personal experience with setting up an instance, using this repository as a base. Assumes basic knowledge of node/npm and javascript.

Added comments to `config.js` showing example URLs that FroJS clients should use, as this took me a while to figure out without any prior sockets.io experience.
